### PR TITLE
Fix hpc.slurm.sbatch swallow non-true argument values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Next release
+============
+
+Fixes
+-----
+- #14: Fix hpc.slurm.sbatch swallow non-true argument values
+
+
 ScriptEngine-HPC 0.5.0
 ======================
 

--- a/scriptengine_hpc/slurm.py
+++ b/scriptengine_hpc/slurm.py
@@ -61,7 +61,7 @@ class Sbatch(Task):
                     sbatch_hetjob_args.append(":")
                 for opt, arg in job_args.items():
                     sbatch_hetjob_args.append(f"--{opt}")
-                    if arg:
+                    if arg is not None:
                         sbatch_hetjob_args.append(j2render(arg, context))
             sbatch_cmd_line.extend(map(str, sbatch_hetjob_args))
 

--- a/scriptengine_hpc/slurm.py
+++ b/scriptengine_hpc/slurm.py
@@ -48,7 +48,7 @@ class Sbatch(Task):
         for opt, arg in self.__dict__.items():
             if is_sbatch_opt(opt):
                 sbatch_general_args.append(f"--{opt}")
-                if arg:
+                if arg is not None:
                     sbatch_general_args.append(j2render(arg, context))
         sbatch_cmd_line.extend(map(str, sbatch_general_args))
 


### PR DESCRIPTION
The `hpc.slurm.sbatch` task swallows any option argument values that evaluate to `False`.

For example,
```
hpc.slurm.sbatch:
  time: 0
```
would result in an error because the `--time` option in the call to `sbatch` would not have any value (instead of 0). This happens for any argument.