### PR TITLE
Implement sbatch_command argument for hpc.slurm.sbatch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Next release
+============
+
+Features
+--------
+- #15: Implement sbatch_command argument for hpc.slurm.sbatch
+
+
 ScriptEngine-HPC 0.5.0
 ======================
 

--- a/scriptengine_hpc/slurm.py
+++ b/scriptengine_hpc/slurm.py
@@ -31,6 +31,7 @@ class Sbatch(Task):
                 "stop_after_submit",
                 "submit_from_batch_job",
                 "set_jobid",
+                "sbatch_command",
             ) and not opt.startswith("_")
 
         if in_batch_job() and not do_recursive_submit():
@@ -42,7 +43,7 @@ class Sbatch(Task):
             return
 
         # Start building the sbatch command line
-        sbatch_cmd_line = [_SBATCH_CMD]
+        sbatch_cmd_line = [self.getarg("sbatch_command", default=_SBATCH_CMD)]
 
         sbatch_general_args = ["--parsable"]
         for opt, arg in self.__dict__.items():


### PR DESCRIPTION
On some systems, the SLURM sbatch command is not simple called `sbatch`. One reason might be the computing centre providing a wrapper script.

Implement a new argument for `hpc.slurm.sbatch` that allows to control which command is called to submit jobs to SLURM.