### PR TITLE
Make sure that se opts/args are not consumed by sbatch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Next release
+============
+
+Fixes
+-----
+- #17: Make sure that se opts/args are not consumed by sbatch
+
+
 ScriptEngine-HPC 0.6.0
 ======================
 

--- a/scriptengine_hpc/slurm.py
+++ b/scriptengine_hpc/slurm.py
@@ -66,6 +66,8 @@ class Sbatch(Task):
                         sbatch_hetjob_args.append(j2render(arg, context))
             sbatch_cmd_line.extend(map(str, sbatch_hetjob_args))
 
+        sbatch_cmd_line.append("--")  # make sure further opts go to se command
+
         scripts = self.getarg("scripts", context, default=None)
         if scripts:
             sbatch_cmd_line.append("se")


### PR DESCRIPTION
It seems that some SLURM installations consume the options meant for the ``se`` command in the ``hpc.slurm.sbatch`` task. So running ``se --nocolor [...]`` on a script that includes the ``hpc.slurm.sbatch`` task could lead to SLURM ``sbatch`` complaining about the unknown ``--nocolor`` option. This has been observed at least at the ECMWF HPC2020 platform.