### PR TITLE
Adapt to new Context class in ScriptEngine

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+Next release
+============
+
+Features
+--------
+- #18: Adapt to new Context class in ScriptEngine
+       (needs ScriptEngine 1.0.0rc1 or later)
+
+
 ScriptEngine-HPC 0.6.1
 ======================
 

--- a/scriptengine_hpc/slurm.py
+++ b/scriptengine_hpc/slurm.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-from scriptengine.context import ContextUpdate
+from scriptengine.context import Context
 from scriptengine.exceptions import ScriptEngineStopException, ScriptEngineTaskRunError
 from scriptengine.jinja import render as j2render
 from scriptengine.tasks.core import Task, timed_runner
@@ -113,7 +113,7 @@ class Sbatch(Task):
         set_jobid = self.getarg("set_jobid", context, default=False)
         if set_jobid:
             if jobid:
-                return ContextUpdate({set_jobid: jobid})
+                return Context({set_jobid: jobid})
             else:
                 self.log_error(
                     "Setting the JOBID was requested, but JOBID could not be parsed"


### PR DESCRIPTION
Return new `Context` class instead of `ContextUpdate` from tasks. 