### PR TITLE
Fix non-string version number in  Github action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
         name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
       -
         name: Install pypa/build
         run: |

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Next release
+============
+
+Fixes
+-----
+- #24: Fix non-string version number in Github action
+
+
 ScriptEngine-HPC 1.0.0rc1
 =========================
 


### PR DESCRIPTION
Prevents `build-n-publish` action from running.