### PR TITLE
Use se command without full path in sbatch command

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Fixes
 -----
 - #26: Update docs on nested keys
 
+Internal changes
+----------------
+- #29: Use se command without full path in sbatch command
+
 
 ScriptEngine-HPC 1.0.0rc2
 =========================

--- a/src/hpctasks/slurm.py
+++ b/src/hpctasks/slurm.py
@@ -68,9 +68,10 @@ class Sbatch(Task):
 
         sbatch_cmd_line.append("--")  # make sure further opts go to se command
 
+        sbatch_cmd_line.append("se")
+
         scripts = self.getarg("scripts", context, default=None)
         if scripts:
-            sbatch_cmd_line.append("se")
             sbatch_cmd_line.extend(
                 map(
                     str,
@@ -79,7 +80,7 @@ class Sbatch(Task):
             )
         else:
             # If no scripts were given, use the original SE command line
-            sbatch_cmd_line.extend(sys.argv)
+            sbatch_cmd_line.extend(sys.argv[1:])
         self.log_debug(f"SLURM sbatch command line: {sbatch_cmd_line}")
 
         self.log_info("Submitting job to SLURM queue")


### PR DESCRIPTION
There are two issues with the current implementation:

1) The `se` command is called differently on the `sbatch` command line, depending on whether the `scripts` parameter is set or not: If it is set, then `se` is called without absolute path, but if `scripts` is not set, `se` is called with the absolute path to the `se` executable (as provided by `sys.argv[0]`. This is inconsistent.

2) Using the absolute path to the `se` executable is potentially a problem: SLURM will copy the script it is given (`se` in this case) to some temporary place and executed in the batch job from there. This will not work if the absolute path is used.

Hence, in both cases (`scripts` parameter set or not) only `se` should be executed in the batch job, relying on PATH resolution to figure out where the executable is.